### PR TITLE
Fix chat API (fixes #3)

### DIFF
--- a/sri_portfolio/sri_portfolio/app/api/chat/route.js
+++ b/sri_portfolio/sri_portfolio/app/api/chat/route.js
@@ -49,7 +49,11 @@ function getAllowedDomains() {
     '127.0.0.1',
     'sriujjwalreddy.vercel.app',
     'www.sriujjwalreddy.com',
-    'sriujjwalreddy.com'
+    'sriujjwalreddy.com',
+    'sri-portfolio-qpyqwkk19-sbeeredd04s-projects.vercel.app',
+    'sri-s-portfolio.vercel.app',
+    'sri-s-portfolio-git-main-sbeeredd04s-projects.vercel.app',
+    'vercel.app' // Allow all Vercel preview deployments
   ];
   
   // Check if ALLOWED_DOMAINS is defined in environment variables

--- a/sri_portfolio/sri_portfolio/app/components/ChatInterface.jsx
+++ b/sri_portfolio/sri_portfolio/app/components/ChatInterface.jsx
@@ -60,10 +60,19 @@ export const ChatInterface = () => {
     setIsTyping(true);
     
     try {
-      // Build the API URL properly to work in both development and production
-      // Remove trailing slash from NETWORK_URL if it exists
-      const baseUrl = NETWORK_URL ? NETWORK_URL.replace(/\/$/, '') : '';
-      const apiUrl = `${baseUrl}/api/chat`;
+      // Determine API URL based on current environment
+      let apiUrl;
+      
+      // If we're in a browser, use relative URL which automatically adapts to the current domain
+      if (typeof window !== 'undefined') {
+        // Use relative URL which works in all environments
+        apiUrl = '/api/chat';
+      } else {
+        // Server-side fallback (should rarely be needed)
+        // Remove trailing slash from NETWORK_URL if it exists
+        const baseUrl = NETWORK_URL ? NETWORK_URL.replace(/\/$/, '') : '';
+        apiUrl = `${baseUrl}/api/chat`;
+      }
       
       console.log('Sending message to API:', apiUrl);
       
@@ -72,7 +81,6 @@ export const ChatInterface = () => {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          // No API key header anymore - using domain-based security instead
         },
         body: JSON.stringify({ 
           message: inputMessage,


### PR DESCRIPTION
This pull request includes updates to the `sri_portfolio` project, focusing on improving domain-based security and environment-specific API URL handling. The most important changes include expanding the list of allowed domains for API requests, refining the logic for determining the API URL based on the environment, and removing the unused API key header.

### Domain-based security improvements:
* [`sri_portfolio/sri_portfolio/app/api/chat/route.js`](diffhunk://#diff-07553cb90be2637e0ffadfe3447049215bd419e7067c1587b3334a0c84d15951L52-R56): Expanded the `getAllowedDomains` function to include additional Vercel preview deployment domains and a general `vercel.app` entry to allow all Vercel preview deployments.

### Environment-specific API handling:
* [`sri_portfolio/sri_portfolio/app/components/ChatInterface.jsx`](diffhunk://#diff-a31a984245d7912a9f075211068d598315f862fd1d79818f3aa3ccc7903df82aL63-R75): Updated the logic in `ChatInterface` to dynamically determine the API URL based on whether the code is running in a browser or on the server. This ensures compatibility across development and production environments.

### Code simplification:
* [`sri_portfolio/sri_portfolio/app/components/ChatInterface.jsx`](diffhunk://#diff-a31a984245d7912a9f075211068d598315f862fd1d79818f3aa3ccc7903df82aL75): Removed the comment about the API key header, as the project now relies solely on domain-based security for API requests.